### PR TITLE
Resolving error with sendria docker image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,10 +46,12 @@ runs:
       with:
         postgresql-version: 16
 
-    - uses: upgundecha/start-sendria-github-action@v1.0.0
-      with:
-        smtp-port: 1025
-        http-port: 1080
+    - name: Start Sendria mail server
+      run: |
+        pip install sendria
+        sendria --smtp-port 1025 --http-port 1080 --db $RUNNER_TEMP/mails.sqlite &
+        sleep 2
+      shell: bash
 
     - name: Set environment variables
       run: |


### PR DESCRIPTION
Sendria dockeria images is too old and failing with the error 

Don't see obvious replacement with another docker image. So went for simple install with pip and that works fine.

```
docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.
```